### PR TITLE
Implement automatic retry into client

### DIFF
--- a/ButterCMS/ButterCMS.csproj
+++ b/ButterCMS/ButterCMS.csproj
@@ -60,6 +60,9 @@
     <Compile Include="Models\PostsMeta.cs" />
     <Compile Include="Models\PostsResponse.cs" />
     <Compile Include="Models\PostStatusEnum.cs" />
+    <Compile Include="Models\Tag.cs" />
+    <Compile Include="Models\TagResponse.cs" />
+    <Compile Include="Models\TagsResponse.cs" />
     <Compile Include="Models\XmlAPIResponse.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SnakeCaseContractResolver.cs" />


### PR DESCRIPTION
This PR causes ButterCMSClient to retry failed requests up to a maximum number of tries. The max number of tries is configurable with the new optional maxRequestTries constructor parameter and is 3 by default. Requests will always execute at least once even when it's set to something like 0 or -10.

Request exceptions are handled as follows
 - If exceptions are thrown but the request eventually succeeds on a subsequent try, the exceptions will be ignored and not thrown.
 - If all the requests fail and all the exceptions are of the same type and have the same .Message property, only one of them will be thrown. This is probably the most common error scenario.
 - If all the requests fail but for different reasons, an AggregateException with one of each unique exception will be thrown. Duplicates within the set of exceptions are collapsed to a single one like in the above scenario. This will probably only happen rarely.
 - If all the requests fail but no exceptions are thrown, a general Exception will be thrown, i.e. "There is a problem with the ButterCMS service". How exactly this would happen, I have no idea. It's just one of those corner cases that made sense to handle in the code. Shouldn't actually be possible.

This PR also fixes an issue where some of the model files were not included in ButterCMS.csproj.
