### PR TITLE
Add support for filtering posts by tag slug, bump NuGet version

### DIFF
--- a/ButterCMS.Tests/ButterCMS.Tests.csproj
+++ b/ButterCMS.Tests/ButterCMS.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ListAuthorsTests.cs" />
     <Compile Include="ListCategoriesTests.cs" />
     <Compile Include="ListPostsTests.cs" />
+    <Compile Include="ListTagsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RetrieveAuthorTests.cs" />
     <Compile Include="RetrieveCategoryTests.cs" />
@@ -75,7 +76,9 @@
     <Compile Include="SitemapTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/ButterCMS.Tests/ListPostsTests.cs
+++ b/ButterCMS.Tests/ListPostsTests.cs
@@ -20,13 +20,15 @@ namespace ButterCMS.Tests
         {
             var posts = butterClient.ListPosts();
             Assert.IsNotNull(posts);
+            CollectionAssert.IsNotEmpty(posts.Data);
         }
 
         [Test]
         public void ListPosts_FullParams_ShouldReturnPosts()
         {   
-            var posts = butterClient.ListPosts(page: 1, pageSize: 2, excludeBody: true, authorSlug: "api-test", categorySlug: "test-category");
+            var posts = butterClient.ListPosts(page: 1, pageSize: 2, excludeBody: true, authorSlug: "api-test", categorySlug: "test-category", tagSlug: "test-tag");
             Assert.IsNotNull(posts);
+            CollectionAssert.IsNotEmpty(posts.Data);
         }
 
         [Test]
@@ -41,13 +43,15 @@ namespace ButterCMS.Tests
         {   
             var posts = await butterClient.ListPostsAsync();
             Assert.IsNotNull(posts);
+            CollectionAssert.IsNotEmpty(posts.Data);
         }
 
         [Test]
         public async Task ListPostsAsync_FullParams_ShouldReturnPosts()
         {   
-            var posts = await butterClient.ListPostsAsync(page: 1, pageSize: 2, excludeBody: true, authorSlug: "api-test", categorySlug: "test-category");
+            var posts = await butterClient.ListPostsAsync(page: 1, pageSize: 2, excludeBody: true, authorSlug: "api-test", categorySlug: "test-category", tagSlug: "test-tag");
             Assert.IsNotNull(posts);
+            CollectionAssert.IsNotEmpty(posts.Data);
         }
 
         [Test]

--- a/ButterCMS.Tests/ListTagsTests.cs
+++ b/ButterCMS.Tests/ListTagsTests.cs
@@ -1,0 +1,54 @@
+﻿using NUnit.Framework;
+using System.Configuration;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Tests
+{
+    [TestFixture]
+    public class ListTagsTests
+    {
+
+        private ButterCMSClient butterClient;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            butterClient = new ButterCMSClient(ConfigurationManager.AppSettings["ButterAuthToken"]);
+        }
+
+        [Test]
+        public void ListTags_ShouldReturnListOfTagsWithoutPosts()
+        {
+            var response = butterClient.ListTags();
+            Assert.IsNotNull(response);
+            Assert.IsNull(response.FirstOrDefault().RecentPosts);
+        }
+
+        [Test]
+        public async Task ListTagsAsync_ShouldReturnListOfTagsWithoutPosts()
+        {
+            var response = await butterClient.ListTagsAsync();
+            Assert.IsNotNull(response);
+            Assert.IsNull(response.FirstOrDefault().RecentPosts);
+        }
+
+        [Test]
+        public void ListTags_ShouldReturnListOfTagsWithPosts()
+        {
+            var response = butterClient.ListTags(true);
+            Assert.IsNotNull(response);
+            Assert.IsNotEmpty(response.FirstOrDefault().RecentPosts);
+        }
+
+        [Test]
+        public async Task ListTagsAsync_ShouldReturnListOfTagsWithPosts()
+        {
+            var response = await butterClient.ListTagsAsync(true);
+            Assert.IsNotNull(response);
+            Assert.IsNotEmpty(response.FirstOrDefault().RecentPosts);
+        }
+
+
+    }
+}

--- a/ButterCMS/ButterCMS.nuspec
+++ b/ButterCMS/ButterCMS.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ButterCMS</id>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <title>ButterCMS</title>
     <authors>ButterCMS, Brandon Nicoll</authors>
     <owners>ButterCMS</owners>

--- a/ButterCMS/ButterCMSClient.cs
+++ b/ButterCMS/ButterCMSClient.cs
@@ -21,19 +21,19 @@ namespace ButterCMS
 
         private const string apiBaseAddress = "https://api.buttercms.com/";
 
-        private const string listPostsEndpoint = "v2/posts";
-        private const string retrievePostEndpoint = "v2/posts/{0}";
-        private const string searchPostsEndpoint = "v2/search";
-        private const string listAuthorsEndpoint = "v2/authors";
-        private const string retrieveAuthorEndpoint = "v2/authors/{0}";
-        private const string listCategoriesEndpoint = "v2/categories";
-        private const string listTagsEndpoint = "v2/tags";
-        private const string retrieveCategoryEndpoint = "v2/categories/{0}";
-        private const string retrieveTagEndpoint = "v2/tags/{0}";
-        private const string rssFeedEndpoint = "v2/feeds/rss";
-        private const string atomEndpoint = "v2/feeds/atom";
-        private const string siteMapEndpoint = "v2/feeds/sitemap";
-        private const string contentEndpoint = "v2/content";
+        private const string listPostsEndpoint = "v2/posts/";
+        private const string retrievePostEndpoint = "v2/posts/{0}/";
+        private const string searchPostsEndpoint = "v2/search/";
+        private const string listAuthorsEndpoint = "v2/authors/";
+        private const string retrieveAuthorEndpoint = "v2/authors/{0}/";
+        private const string listCategoriesEndpoint = "v2/categories/";
+        private const string listTagsEndpoint = "v2/tags/";
+        private const string retrieveCategoryEndpoint = "v2/categories/{0}/";
+        private const string retrieveTagEndpoint = "v2/tags/{0}/";
+        private const string rssFeedEndpoint = "v2/feeds/rss/";
+        private const string atomEndpoint = "v2/feeds/atom/";
+        private const string siteMapEndpoint = "v2/feeds/sitemap/";
+        private const string contentEndpoint = "v2/content/";
         private const int defaultPageSize = 10;
         private string authTokenParam
         {
@@ -58,21 +58,21 @@ namespace ButterCMS
             serializerSettings.ContractResolver = new SnakeCaseContractResolver();
         }
 
-        public PostsResponse ListPosts(int page = 1, int pageSize = defaultPageSize, bool excludeBody = false, string authorSlug = null, string categorySlug = null)
+        public PostsResponse ListPosts(int page = 1, int pageSize = defaultPageSize, bool excludeBody = false, string authorSlug = null, string categorySlug = null, string tagSlug = null)
         {
-            var queryString = ParseListPostsParams(page, pageSize, excludeBody, authorSlug, categorySlug);
+            var queryString = ParseListPostsParams(page, pageSize, excludeBody, authorSlug, categorySlug, tagSlug);
             var postsResponse = JsonConvert.DeserializeObject<PostsResponse>(Execute(queryString), serializerSettings);
             return postsResponse;
         }
 
-        public async Task<PostsResponse> ListPostsAsync(int page = 1, int pageSize = defaultPageSize, bool excludeBody = false, string authorSlug = null, string categorySlug = null)
+        public async Task<PostsResponse> ListPostsAsync(int page = 1, int pageSize = defaultPageSize, bool excludeBody = false, string authorSlug = null, string categorySlug = null, string tagSlug = null)
         {
-            var queryString = ParseListPostsParams(page, pageSize, excludeBody, authorSlug, categorySlug);
+            var queryString = ParseListPostsParams(page, pageSize, excludeBody, authorSlug, categorySlug, tagSlug);
             var postsResponse = JsonConvert.DeserializeObject<PostsResponse>(await ExecuteAsync(queryString), serializerSettings);
             return postsResponse;
         }
 
-        private string ParseListPostsParams(int page = 1, int pageSize = defaultPageSize, bool excludeBody = false, string authorSlug = null, string categorySlug = null)
+        private string ParseListPostsParams(int page = 1, int pageSize = defaultPageSize, bool excludeBody = false, string authorSlug = null, string categorySlug = null, string tagSlug = null)
         {
             var queryString = new StringBuilder();
             queryString.Append(listPostsEndpoint);
@@ -102,6 +102,11 @@ namespace ButterCMS
             if (!string.IsNullOrEmpty(categorySlug))
             {
                 queryString.Append(string.Format("&category_slug={0}", categorySlug));
+            }
+
+            if (!string.IsNullOrEmpty(tagSlug))
+            {
+                queryString.Append(string.Format("&tag_slug={0}", tagSlug));
             }
             return queryString.ToString();
         }


### PR DESCRIPTION
This pull request adds support for filtering by tag slug to the ListPosts() and ListPostsAsync() methods. Also fixed the issue where lack of trailing slashes in the URLs were causing 301 redirects.