### PR TITLE
Fix SSL error on .NET versions prior to 4.6

### DIFF
--- a/ButterCMS.Tests/App.config
+++ b/ButterCMS.Tests/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <add key="ButterAuthToken" value=""/> 
   </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/ButterCMS.Tests/ButterCMS.Tests.csproj
+++ b/ButterCMS.Tests/ButterCMS.Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ButterCMS.Tests</RootNamespace>
     <AssemblyName>ButterCMS.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ButterCMS/ButterCMS.nuspec
+++ b/ButterCMS/ButterCMS.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ButterCMS</id>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <title>ButterCMS</title>
     <authors>ButterCMS, Brandon Nicoll</authors>
     <owners>ButterCMS</owners>

--- a/ButterCMS/ButterCMSClient.cs
+++ b/ButterCMS/ButterCMSClient.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -46,6 +47,7 @@ namespace ButterCMS
 
         public ButterCMSClient(string authToken, TimeSpan? timeOut = null, int maxRequestTries = 3)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             httpClient = new HttpClient
             {
                 Timeout = timeOut ?? defaultTimeout,


### PR DESCRIPTION
Previously to this change set, when the ButterCMS client was used in a project with a .NET version lower than .NET 4.6, it would try to connect to the ButterCMS servers using SSL 3.0, TLS 1.0, or TLS 1.1. The ButterCMS servers use TLS 1.2, which was incompatible with these other security standards and would cause an exception to be thrown at runtime.

This change forces .NET to always choose TLS 1.2, which fixes the error.