### PR TITLE
Pages support & content fields updates

### DIFF
--- a/ButterCMS.Tests/App.config
+++ b/ButterCMS.Tests/App.config
@@ -3,4 +3,4 @@
   <appSettings>
     <add key="ButterAuthToken" value=""/> 
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/ButterCMS.Tests/ButterCMS.Tests.csproj
+++ b/ButterCMS.Tests/ButterCMS.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ButterCMS.Tests</RootNamespace>
     <AssemblyName>ButterCMS.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -65,12 +65,16 @@
     <Compile Include="AtomFeedTests.cs" />
     <Compile Include="ListAuthorsTests.cs" />
     <Compile Include="ListCategoriesTests.cs" />
+    <Compile Include="ListPagesTests.cs" />
     <Compile Include="ListPostsTests.cs" />
     <Compile Include="ListTagsTests.cs" />
+    <Compile Include="Models\TeamMembersHeadline.cs" />
+    <Compile Include="Models\things.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RetrieveAuthorTests.cs" />
     <Compile Include="RetrieveCategoryTests.cs" />
     <Compile Include="RetrieveContentFieldsTests.cs" />
+    <Compile Include="RetrievePageTests.cs" />
     <Compile Include="RetrievePostTests.cs" />
     <Compile Include="RssFeedTests.cs" />
     <Compile Include="SearchPostsTests.cs" />

--- a/ButterCMS.Tests/ListPagesTests.cs
+++ b/ButterCMS.Tests/ListPagesTests.cs
@@ -1,5 +1,6 @@
 ﻿using ButterCMS.Tests.Models;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Threading.Tasks;
 namespace ButterCMS.Tests
@@ -18,7 +19,11 @@ namespace ButterCMS.Tests
         [Test]
         public void ListPages_ShouldReturnPages()
         {
-            var response = butterClient.ListPages<things>("things");
+            var dict = new Dictionary<string, string>()
+            {
+                {"fields.thing1", "1"},
+            };
+            var response = butterClient.ListPages<things>("things", dict);
             Assert.IsNotNull(response);
         }
 

--- a/ButterCMS.Tests/ListPagesTests.cs
+++ b/ButterCMS.Tests/ListPagesTests.cs
@@ -1,0 +1,46 @@
+﻿using ButterCMS.Tests.Models;
+using NUnit.Framework;
+using System.Configuration;
+using System.Threading.Tasks;
+namespace ButterCMS.Tests
+{
+    [TestFixture]
+    public class ListPagesTests
+    {
+        private ButterCMSClient butterClient;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            butterClient = new ButterCMSClient(ConfigurationManager.AppSettings["ButterAuthToken"]);
+        }
+
+        [Test]
+        public void ListPages_ShouldReturnPages()
+        {
+            var response = butterClient.ListPages<things>("things");
+            Assert.IsNotNull(response);
+        }
+
+        [Test]
+        public async Task ListPagesAsync_ShouldReturnPages()
+        {
+            var response = await butterClient.ListPagesAsync<things>("things");
+            Assert.IsNotNull(response);
+        }
+
+        [Test]
+        public void ListPages_NoResults_ShouldReturnNull()
+        {
+            var response =  butterClient.ListPages<things>("nothings");
+            Assert.IsNull(response);
+        }
+
+        [Test]
+        public async Task ListPagesAsync_NoResults_ShouldReturnNull()
+        {
+            var response = await butterClient.ListPagesAsync<things>("nothings");
+            Assert.IsNull(response);
+        }
+    }
+}

--- a/ButterCMS.Tests/Models/TeamMembersHeadline.cs
+++ b/ButterCMS.Tests/Models/TeamMembersHeadline.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Tests.Models
+{
+    public class TeamMembersHeadline
+    {
+        public Team_Members[] team_members { get; set; }
+        public string homepage_headline { get; set; }
+    }
+
+    public class Team_Members
+    {
+        public string bio { get; set; }
+        public string picture { get; set; }
+        public string name { get; set; }
+    }
+
+}

--- a/ButterCMS.Tests/Models/things.cs
+++ b/ButterCMS.Tests/Models/things.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Tests.Models
+{
+    public class things
+    {
+        public string thing1 { get; set; }
+        public string thing2 { get; set; }
+    }
+
+}

--- a/ButterCMS.Tests/RetrieveContentFieldsTests.cs
+++ b/ButterCMS.Tests/RetrieveContentFieldsTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using ButterCMS.Tests.Models;
+using NUnit.Framework;
 using System.Threading.Tasks;
 
 namespace ButterCMS.Tests
@@ -7,7 +8,7 @@ namespace ButterCMS.Tests
     public class RetrieveContentFieldsTests
     {
         [Test]
-        public void RetrieveContentFieldsJSON_ShouldReturnDictionaryStringDynamic()
+        public void RetrieveContentFieldsJSON_ShouldReturnDictionaryString()
         {
             var butterClient = new ButterCMSClient("321478403e868f0fc41f0115731f330ff720ce0b");
             var keys = new string[2] {"team_members[name=Elon]", "homepage_headline"};
@@ -26,7 +27,7 @@ namespace ButterCMS.Tests
         }
 
         [Test]
-        public async Task RetrieveContentFieldsJSONAsync_ShouldReturnDictionaryStringDynamic()
+        public async Task RetrieveContentFieldsJSONAsync_ShouldReturnDictionaryString()
         {
             var butterClient = new ButterCMSClient("321478403e868f0fc41f0115731f330ff720ce0b");
             var keys = new string[2] { "team_members[name=Elon]", "homepage_headline" };
@@ -42,6 +43,33 @@ namespace ButterCMS.Tests
             var actual = await butterClient.RetrieveContentFieldsJSONAsync(keys);
             var expected = string.Empty;
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void RetrieveContentFields_ShouldReturnTeamMembersHeadline()
+        {
+            var butterClient = new ButterCMSClient("321478403e868f0fc41f0115731f330ff720ce0b");
+            var keys = new string[2] { "team_members[name=Elon]", "homepage_headline" };
+            var teamMembersAndHeadline = butterClient.RetrieveContentFields<TeamMembersHeadline>(keys);
+            Assert.IsNotNull(teamMembersAndHeadline);
+        }
+
+        [Test]
+        public async Task RetrieveContentFieldsAsync_ShouldReturnTeamMembersHeadline()
+        {
+            var butterClient = new ButterCMSClient("321478403e868f0fc41f0115731f330ff720ce0b");
+            var keys = new string[2] { "team_members[name=Elon]", "homepage_headline" };
+            var teamMembersAndHeadline = await butterClient.RetrieveContentFieldsAsync<TeamMembersHeadline>(keys);
+            Assert.IsNotNull(teamMembersAndHeadline);
+        }
+
+        [Test]
+        
+        public void  RetrieveContentFields_ShouldThrowContentFieldObjectMismatchException()
+        {
+            var butterClient = new ButterCMSClient("321478403e868f0fc41f0115731f330ff720ce0b");
+            var keys = new string[2] { "team_members[name=Elon]", "homepage_headline" };
+            Assert.Throws<ContentFieldObjectMismatchException>(() => butterClient.RetrieveContentFields<string>(keys));
         }
     }
 }

--- a/ButterCMS.Tests/RetrievePageTests.cs
+++ b/ButterCMS.Tests/RetrievePageTests.cs
@@ -1,0 +1,48 @@
+﻿using ButterCMS.Tests.Models;
+using NUnit.Framework;
+using System.Configuration;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Tests
+{
+    [TestFixture]
+    public class RetrievePageTests
+    {
+        private ButterCMSClient butterClient;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            butterClient = new ButterCMSClient(ConfigurationManager.AppSettings["ButterAuthToken"]);
+        }
+
+        [Test]
+        public void ListPage_ShouldReturnPage()
+        {
+            var response = butterClient.RetrievePage<things>("things", "thingsthingsthings");
+            Assert.IsNotNull(response);
+        }
+
+        [Test]
+        public async Task ListPageAsync_ShouldReturnPage()
+        {
+            var response = await butterClient.RetrievePageAsync<things>("things", "thingsthingsthings");
+            Assert.IsNotNull(response);
+        }
+
+        [Test]
+        public void ListPage_NoResults_ShouldReturnNull()
+        {
+            var response = butterClient.RetrievePage<things>("nothings", "nothings");
+            Assert.IsNull(response);
+        }
+
+        [Test]
+        public async Task ListPageAsync_NoResults_ShouldReturnNull()
+        {
+            var response = await butterClient.RetrievePageAsync<things>("nothings", "nothings");
+            Assert.IsNull(response);
+        }
+
+    }
+}

--- a/ButterCMS/ButterCMS.csproj
+++ b/ButterCMS/ButterCMS.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ButterCMS</RootNamespace>
     <AssemblyName>ButterCMS</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -46,13 +46,18 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ButterCMSClient.cs" />
+    <Compile Include="Exceptions\ContentFieldObjectMismatchException.cs" />
     <Compile Include="Exceptions\InvalidKeyException.cs" />
+    <Compile Include="Exceptions\PagesObjectMismatchException.cs" />
     <Compile Include="Models\Author.cs" />
     <Compile Include="Models\AuthorResponse.cs" />
     <Compile Include="Models\AuthorsResponse.cs" />
     <Compile Include="Models\CategoriesResponse.cs" />
     <Compile Include="Models\Category.cs" />
     <Compile Include="Models\CategoryResponse.cs" />
+    <Compile Include="Models\ContentResponse.cs" />
+    <Compile Include="Models\Page.cs" />
+    <Compile Include="Models\PagesResponse.cs" />
     <Compile Include="Models\Post.cs" />
     <Compile Include="Models\PostLight.cs" />
     <Compile Include="Models\PostMeta.cs" />
@@ -60,6 +65,7 @@
     <Compile Include="Models\PostsMeta.cs" />
     <Compile Include="Models\PostsResponse.cs" />
     <Compile Include="Models\PostStatusEnum.cs" />
+    <Compile Include="Models\PageMeta.cs" />
     <Compile Include="Models\Tag.cs" />
     <Compile Include="Models\TagResponse.cs" />
     <Compile Include="Models\TagsResponse.cs" />
@@ -68,7 +74,9 @@
     <Compile Include="SnakeCaseContractResolver.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ButterCMS.nuspec" />
+    <None Include="ButterCMS.nuspec">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/ButterCMS/ButterCMS.nuspec
+++ b/ButterCMS/ButterCMS.nuspec
@@ -17,11 +17,11 @@
     <tags>ButterCMS CMS</tags>
     <language>en-US</language>
     <dependencies>
-          <dependency id="Newtonsoft.Json" version="7.0.1"/>
-          <dependency id="System.Net.Http" version="4.0.0"/>
+          <dependency id="Newtonsoft.Json" version="10.0.3"/>
+          <dependency id="System.Net.Http" version="4.3.0"/>
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\ButterCMS*.*" target="lib\net45" />
+    <file src="bin\Release\ButterCMS*.*" target="lib\net461" />
   </files>
 </package>

--- a/ButterCMS/ButterCMS.nuspec
+++ b/ButterCMS/ButterCMS.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ButterCMS</id>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
     <title>ButterCMS</title>
     <authors>ButterCMS, Brandon Nicoll</authors>
     <owners>ButterCMS</owners>

--- a/ButterCMS/ButterCMSClient.cs
+++ b/ButterCMS/ButterCMSClient.cs
@@ -36,6 +36,8 @@ namespace ButterCMS
         private const string atomEndpoint = "v2/feeds/atom/";
         private const string siteMapEndpoint = "v2/feeds/sitemap/";
         private const string contentEndpoint = "v2/content/";
+        private const string listPagesEndpoint = "v2/pages/{0}/";
+        private const string retrievePageEndpoint = "v2/pages/{0}/{1}/";
         private const int defaultPageSize = 10;
         private string authTokenParam
         {
@@ -54,7 +56,7 @@ namespace ButterCMS
                 Timeout = timeOut ?? defaultTimeout,
                 BaseAddress = new Uri(apiBaseAddress)
             };
-            httpClient.DefaultRequestHeaders.Add("X-Butter-Client", Assembly.GetExecutingAssembly().GetName().Version.ToString());
+            httpClient.DefaultRequestHeaders.Add("X-Butter-Client", ".NET/" + Assembly.GetExecutingAssembly().GetName().Version.ToString());
             this.maxRequestTries = maxRequestTries;
             this.authToken = authToken;
 
@@ -451,20 +453,208 @@ namespace ButterCMS
             }
         }
 
-        public string RetrieveContentFieldsJSON(string[] keys)
+        public string RetrieveContentFieldsJSON(string[] keys, Dictionary<string, string> parameterDictionary = null)
         {
             var keysQueryString = string.Join(",", keys);
-            var queryString = string.Format("{0}?{1}&keys={2}", contentEndpoint, authTokenParam, keysQueryString);
-            var contentFields = Execute(queryString);
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format("{0}?{1}&keys={2}", contentEndpoint, authTokenParam, keysQueryString));
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var contentFields = Execute(queryString.ToString());
             return contentFields;
         }
 
-        public async Task<string> RetrieveContentFieldsJSONAsync(string[] keys)
+        public async Task<string> RetrieveContentFieldsJSONAsync(string[] keys, Dictionary<string, string> parameterDictionary = null)
         {
             var keysQueryString = string.Join(",", keys);
-            var queryString = string.Format("{0}?{1}&keys={2}", contentEndpoint, authTokenParam, keysQueryString);
-            var contentFields = await ExecuteAsync(queryString);
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format("{0}?{1}&keys={2}", contentEndpoint, authTokenParam, keysQueryString));
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var contentFields = await ExecuteAsync(queryString.ToString());
             return contentFields;
+        }
+
+        public T RetrieveContentFields<T>(string[] keys, Dictionary<string, string> parameterDictionary = null) where T : class
+        {
+            var keysQueryString = string.Join(",", keys);
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format("{0}?{1}&keys={2}", contentEndpoint, authTokenParam, keysQueryString));
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var contentFieldsJSON = Execute(queryString.ToString());
+            try
+            {
+                var contentFields = JsonConvert.DeserializeObject<ContentResponse<T>>(contentFieldsJSON);
+                return contentFields.Data;
+            }
+            catch
+            {
+                throw new ContentFieldObjectMismatchException(string.Format("The Butter library was unable to deserialize the response object to the given object. Response from server: {0}", contentFieldsJSON));
+            }
+        }
+
+        public async Task<T> RetrieveContentFieldsAsync<T>(string[] keys, Dictionary<string, string> parameterDictionary = null) where T : class
+        {
+            var keysQueryString = string.Join(",", keys);
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format("{0}?{1}&keys={2}", contentEndpoint, authTokenParam, keysQueryString));
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var contentFieldsJSON = await ExecuteAsync(queryString.ToString());
+            try
+            {
+                var contentFields = JsonConvert.DeserializeObject<ContentResponse<T>>(contentFieldsJSON);
+                return contentFields.Data;
+            }
+            catch
+            {
+                throw new ContentFieldObjectMismatchException(string.Format("The Butter library was unable to deserialize the response object to the given object. Response from server: {0}", contentFieldsJSON));
+            }
+        }
+
+        public PagesResponse<T> ListPages<T>(string pageType, Dictionary<string, string> parameterDictionary = null) where T : class
+        {
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format(listPagesEndpoint, pageType));
+            queryString.Append("?");
+            queryString.Append(authTokenParam);
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var listPagesJSON = Execute(queryString.ToString());
+            try
+            {
+                var response = JsonConvert.DeserializeObject<PagesResponse<T>>(listPagesJSON);
+                return response;
+            }
+            catch
+            {
+                throw new PagesObjectMismatchException(string.Format("The Butter library was unable to deserialize the response object to the given object. Response from server: {0}", listPagesJSON));
+            }
+            
+        }
+        public async Task<PagesResponse<T>> ListPagesAsync<T>(string pageType, Dictionary<string, string> parameterDictionary = null) where T : class
+        {
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format(listPagesEndpoint, pageType));
+            queryString.Append("?");
+            queryString.Append(authTokenParam);
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var listPagesJSON = await ExecuteAsync(queryString.ToString());
+            try
+            {
+                var response = JsonConvert.DeserializeObject<PagesResponse<T>>(listPagesJSON);
+                return response;
+            }
+            catch
+            {
+                throw new PagesObjectMismatchException(string.Format("The Butter library was unable to deserialize the response object to the given object. Response from server: {0}", listPagesJSON));
+            }
+        }
+
+        public Page<T> RetrievePage<T>(string pageType, string pageSlug, Dictionary<string, string> parameterDictionary = null) where T : class
+        {
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format(retrievePageEndpoint, pageType, pageSlug));
+            queryString.Append("?");
+            queryString.Append(authTokenParam);
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var retrievePageJSON = Execute(queryString.ToString());
+            try
+            {
+                var response = JsonConvert.DeserializeObject<Page<T>>(retrievePageJSON);
+                return response;
+            }
+            catch
+            {
+                throw new PagesObjectMismatchException(string.Format("The Butter library was unable to deserialize the response object to the given object. Response from server: {0}", retrievePageJSON));
+            }
+        }
+
+        public async Task<Page<T>> RetrievePageAsync<T>(string pageType, string pageSlug, Dictionary<string, string> parameterDictionary = null) where T : class
+        {
+            var queryString = new StringBuilder();
+            queryString.Append(string.Format(retrievePageEndpoint, pageType, pageSlug));
+            queryString.Append("?");
+            queryString.Append(authTokenParam);
+            if (parameterDictionary != null && parameterDictionary.Count > 0)
+            {
+                foreach (var parameterPair in parameterDictionary)
+                {
+                    queryString.Append("&");
+                    queryString.Append(parameterPair.Key);
+                    queryString.Append("=");
+                    queryString.Append(parameterPair.Value);
+                }
+            }
+            var retrievePageJSON = await ExecuteAsync(queryString.ToString());
+            try
+            {
+                var response = JsonConvert.DeserializeObject<Page<T>>(retrievePageJSON);
+                return response;
+            }
+            catch
+            {
+                throw new PagesObjectMismatchException(string.Format("The Butter library was unable to deserialize the response object to the given object. Response from server: {0}", retrievePageJSON));
+            }
         }
 
         private string Execute(string queryString)

--- a/ButterCMS/ButterCMSClient.cs
+++ b/ButterCMS/ButterCMSClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -53,6 +54,7 @@ namespace ButterCMS
                 Timeout = timeOut ?? defaultTimeout,
                 BaseAddress = new Uri(apiBaseAddress)
             };
+            httpClient.DefaultRequestHeaders.Add("X-Butter-Client", Assembly.GetExecutingAssembly().GetName().Version.ToString());
             this.maxRequestTries = maxRequestTries;
             this.authToken = authToken;
 

--- a/ButterCMS/Exceptions/ContentFieldObjectMismatchException.cs
+++ b/ButterCMS/Exceptions/ContentFieldObjectMismatchException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace ButterCMS
+{
+    public class ContentFieldObjectMismatchException : Exception
+    {
+        public ContentFieldObjectMismatchException()
+        {
+        }
+        public ContentFieldObjectMismatchException(string message)
+        : base(message)
+        {
+        }
+        public ContentFieldObjectMismatchException(string message, Exception inner)
+        : base(message, inner)
+        {
+        }
+    }
+}

--- a/ButterCMS/Exceptions/PagesObjectMismatchException.cs
+++ b/ButterCMS/Exceptions/PagesObjectMismatchException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButterCMS
+{
+    public class PagesObjectMismatchException : Exception
+    {
+        public PagesObjectMismatchException()
+        {
+        }
+        public PagesObjectMismatchException(string message)
+        : base(message)
+        {
+        }
+        public PagesObjectMismatchException(string message, Exception inner)
+        : base(message, inner)
+        {
+        }
+    }
+}

--- a/ButterCMS/Models/ContentResponse.cs
+++ b/ButterCMS/Models/ContentResponse.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Models
+{
+    public class ContentResponse<T>
+    {
+        public T Data { get; set; }
+    }
+}

--- a/ButterCMS/Models/Page.cs
+++ b/ButterCMS/Models/Page.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace ButterCMS.Models
+{
+    public class Page<T>
+    {
+        public string Slug { get; set; }
+        public T Fields { get; set; }
+    }
+}

--- a/ButterCMS/Models/PageMeta.cs
+++ b/ButterCMS/Models/PageMeta.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Models
+{
+    public class PageMeta
+    {
+        public int Count { get; set; }
+        public int? PreviousPage { get; set; }
+        public int? NextPage { get; set; }
+    }
+}

--- a/ButterCMS/Models/PagesResponse.cs
+++ b/ButterCMS/Models/PagesResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ButterCMS.Models
+{
+    public class PagesResponse<T>
+    {
+        public PageMeta Meta { get; set; }
+        public IEnumerable<Page<T>> Data { get; set; }
+    }
+}

--- a/ButterCMS/Properties/AssemblyInfo.cs
+++ b/ButterCMS/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/ButterCMS/packages.config
+++ b/ButterCMS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Page<ProductPage> saleOfTheDayPage = butterClient.RetrievePage<ProductPage>("pro
 | Property | Type|
 |----|---|
 |Slug| string|
-|T| Fields|
+|Fields|T|
 
 ## Exceptions
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ var teamMembersAndHeadline = butterClient.RetrieveContentFields<TeamMembersHeadl
 
 ```
 
-**Legacy documentation** :
+**Legacy Content Fields JSON documentation** :
 
 As demonstrated in the [Content Fields documentation](https://buttercms.com/docs/api/#content-fields), any number of user-defined content fields can be retrieved from the API. Expanding on the examples in the docs, https://api.buttercms.com/v2/content/?keys=homepage_headline,team_members&auth_token=321478403e868f0fc41f0115731f330ff720ce0b returns an object that won't fit neatly in one C# object. For this reason, the client forwards the JSON string response and leaves deserialization up to the caller.
 
@@ -273,7 +273,7 @@ PagesResponse<ProductPage> productPages = butterClient.ListPages<ProductPage>("p
 
 ```
 ### Retrieve a Single Page
-Retrieving a single page returns a [Page&gt;T&lt;](page-class) object
+Retrieving a single page returns a [Page&lt;T&gt;](#page-class) object
 
 #### RetrievePage() Parameters:
 | Parameter|Description|

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Retrieve a fully generated sitemap for your blog.
 
 **New in version 1.3.0**
 
-By the power of .NET generics, Content Fields can now be deserialized by the libary! The former method that would defer deserialization is still available to ease transition.
+By the power of .NET generics, Content Fields can now be deserialized by the library! The former method that would defer deserialization is still available to ease transition.
 
 #### RetrieveContentFields() Parameters:
 | Parameter|Description|
@@ -220,7 +220,7 @@ By the power of .NET generics, Content Fields can now be deserialized by the lib
 #### Examples:
 ```C#
 var keys = new string[2] { "team_members[name=Elon]", "homepage_headline" };
-var dict = new Dictionary&lt;string, string&gt;()
+var dict = new Dictionary<string, string>()
             {
                 { "locale", "de" },
                 { "test", "1" }
@@ -229,7 +229,7 @@ var teamMembersAndHeadline = butterClient.RetrieveContentFields<TeamMembersHeadl
 
 ```
 
-**Legacy Content Fields JSON documentation** :
+** Content Fields JSON documentation** :
 
 As demonstrated in the [Content Fields documentation](https://buttercms.com/docs/api/#content-fields), any number of user-defined content fields can be retrieved from the API. Expanding on the examples in the docs, https://api.buttercms.com/v2/content/?keys=homepage_headline,team_members&auth_token=321478403e868f0fc41f0115731f330ff720ce0b returns an object that won't fit neatly in one C# object. For this reason, the client forwards the JSON string response and leaves deserialization up to the caller.
 
@@ -254,7 +254,7 @@ var contentFields = await butterClient.RetrieveContentFieldsJSONAsync(keys, dict
 ## Pages
 ### List Pages
 
-Listing Pages returns a [PagesResponse](#pagesresponse-class) object
+Listing Pages returns a [PagesResponse](#pagesresponse-class) object. Full API documentation can be found at https://buttercms.com/docs/api/#list-pages-for-a-page-type.
 
 #### ListPages() Parameters:
 | Parameter|Description|
@@ -269,7 +269,19 @@ Listing Pages returns a [PagesResponse](#pagesresponse-class) object
 
 #### Examples:
 ```C#
-PagesResponse<ProductPage> productPages = butterClient.ListPages<ProductPage>("products");
+PagesResponse<YourPage> productPages = butterClient.ListPages<YourPage>("products");
+
+var paramterDict = new Dictionary<string, string>() 
+{
+    {"preview", "1"},
+    {"field.category", "appetizers"},
+    {"field.main_ingredient", "cheese"},
+    {"order", "-date_published"},
+    {"page", "7"},
+    {"page_size", "10"}
+};
+
+PagesResponse<ExamplePage> recipePages = await butterClient.ListPagesAsync<ExamplePage>("recipes", parameterDict);
 
 ```
 ### Retrieve a Single Page
@@ -290,6 +302,12 @@ Retrieving a single page returns a [Page&lt;T&gt;](#page-class) object
 #### Examples:
 ```C#
 Page<ProductPage> saleOfTheDayPage = butterClient.RetrievePage<ProductPage>("products", "saleoftheday");
+
+var paramterDict = new Dictionary<string, string>() 
+{
+    {"preview", "1"},
+};
+Page<ExamplePage> stuffedArtichokesPage = await butterClient.RetrievePageAsync<ExamplePage>("recipes", "stuffed-artichokes", paramterDict);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ var teamMembersAndHeadline = butterClient.RetrieveContentFields<TeamMembersHeadl
 
 ** Content Fields JSON documentation** :
 
-As demonstrated in the [Content Fields documentation](https://buttercms.com/docs/api/#content-fields), any number of user-defined content fields can be retrieved from the API. Expanding on the examples in the docs, https://api.buttercms.com/v2/content/?keys=homepage_headline,team_members&auth_token=321478403e868f0fc41f0115731f330ff720ce0b returns an object that won't fit neatly in one C# object. For this reason, the client forwards the JSON string response and leaves deserialization up to the caller.
+As demonstrated in the [Content Fields documentation](https://buttercms.com/docs/api/#content-fields), any number of user-defined content fields can be retrieved from the API, these can get complicated in C# and you may choose to handle the response yourself. The RetrieveContentFieldsJSON() method will return the raw JSON response from the Butter API.
 
 #### RetrieveContentFieldsJSON() Parameters:
 | Parameter|Description|


### PR DESCRIPTION
This PR adds support for Butter Pages. It also expands functionality for Content Fields to support new API features, as well as removing the need to offload deserializing Content Field objects to the caller.